### PR TITLE
Added empty conftest.py

### DIFF
--- a/dbfunctions.py
+++ b/dbfunctions.py
@@ -30,7 +30,7 @@ class Wikidb(object):
         history_id = hash(str(subject+body))
         self.cur.execute("""INSERT OR REPLACE INTO history (body, history_id)
         VALUES (?,?)""", (body, history_id))
-        self.cur.execute("""INSERT INTO authorship(subject, author_email, history_id)
+        self.cur.execute("""INSERT OR REPLACE INTO authorship(subject, author_email, history_id)
         VALUES(?, ?, ?)""", (subject.lower(), author_email.lower(), history_id))
         self.conn.commit()
 

--- a/tests/test_dbfunctions.py
+++ b/tests/test_dbfunctions.py
@@ -1,5 +1,19 @@
 import dbfunctions
+import pytest
+from hypothesis import given, strategies as st
+
+@pytest.fixture
+def db(scope='function'):
+    db = dbfunctions.Wikidb(':memory:')
+    yield db
+    db = None
 
 def test_create_article():
     db = dbfunctions.Wikidb(':memory:')
     db.put("Test Subject", "Test Body")
+
+@given(subject=st.text(), body=st.text())
+def test_db_scaleout(subject, body, db):
+    """ Aim for 10,000 articles """
+    for i in range(0,9999):
+        db.put(subject, body)


### PR DESCRIPTION
This apparently is a way to avoid having to add the working directory to pythonpath and still have pytest check there for modules.
Reference: http://stackoverflow.com/questions/20971619/ensuring-py-test-includes-the-application-directory-in-sys-path/20972950#20972950